### PR TITLE
SecurityManager initialization #7

### DIFF
--- a/src/main/java/br/com/caelum/vraptor/security/produces/SecurityFacade.java
+++ b/src/main/java/br/com/caelum/vraptor/security/produces/SecurityFacade.java
@@ -7,10 +7,12 @@ import java.util.Collection;
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.context.SessionScoped;
+import javax.enterprise.event.Observes;
 import javax.enterprise.inject.Any;
 import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 import org.apache.shiro.SecurityUtils;
 import org.apache.shiro.authc.AuthenticationListener;
@@ -30,7 +32,7 @@ import org.slf4j.LoggerFactory;
 
 import br.com.caelum.vraptor.security.strategy.ShiroInitConfigStrategy;
 
-@ApplicationScoped
+@Singleton
 public class SecurityFacade {
 
 	@Inject @Any private Instance<AuthenticationListener> authenticationListeners;
@@ -40,8 +42,8 @@ public class SecurityFacade {
 
 	private static final Logger log = LoggerFactory.getLogger(SecurityFacade.class);
 
-	@PostConstruct
-	public void init() {
+	public void init(@Observes VRaptorShiroInit initEvent) {
+		log.info(initEvent.getMessage());
 		log.info("Initializing Shiro SecurityManager");
 
 		ModularRealmAuthenticator authenticator = new ModularRealmAuthenticator();

--- a/src/main/java/br/com/caelum/vraptor/security/produces/VRaptorShiroInit.java
+++ b/src/main/java/br/com/caelum/vraptor/security/produces/VRaptorShiroInit.java
@@ -1,0 +1,16 @@
+package br.com.caelum.vraptor.security.produces;
+
+/**
+ * Created by danilo on 02/01/17.
+ */
+public class VRaptorShiroInit {
+	private final String message;
+
+	public VRaptorShiroInit(String message) {
+		this.message = message;
+	}
+
+	public String getMessage() {
+		return message;
+	}
+}


### PR DESCRIPTION
This corrects the "SecurityManager initialization" problem, but it will be necessary to update the doc for the plugin users to create a Class that listens to the "VRaptorInitialized" VRaptor initialization event and triggers the VRaptor-Shiro boot event "VRaptorShiroInit"

Here is an example of the class that should be implemented in projects that use the "vraptor-shiro" plugin.

```
import br.com.caelum.vraptor.events.VRaptorInitialized;
import br.com.caelum.vraptor.security.produces.VRaptorShiroInit;
import org.slf4j.Logger;
import org.slf4j.LoggerFactory;

import javax.enterprise.event.Event;
import javax.enterprise.event.Observes;
import javax.inject.Inject;


public class VRaptorShiroInitialization {

	private static final Logger log = LoggerFactory.getLogger(VRaptorShiroInitialization.class);

	@Inject
	private Event<VRaptorShiroInit> shiroEvents;


	protected void init(@Observes VRaptorInitialized initializedEvent){
		shiroEvents.fire(new VRaptorShiroInit("Project [example] initialized"));
	}
}
```